### PR TITLE
Bumped OpenRefine to 3.7.6

### DIFF
--- a/knowledge-graph/Dockerfile
+++ b/knowledge-graph/Dockerfile
@@ -40,7 +40,7 @@ RUN mamba install --quiet -y \
 
 
 # Install OpenRefine
-ENV OPENREFINE_VERSION=3.4.1
+ENV OPENREFINE_VERSION=3.7.6
 RUN cd /opt && \
     wget https://github.com/OpenRefine/OpenRefine/releases/download/$OPENREFINE_VERSION/openrefine-linux-$OPENREFINE_VERSION.tar.gz && \
     tar xzf openrefine-linux-$OPENREFINE_VERSION.tar.gz && \


### PR DESCRIPTION
OpenRefine is currently not working (throwing a HTTP 504 Error: Gateway Time-out).

This fixes #2 